### PR TITLE
Fix URL Authentication/Access control README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,6 @@ and everything. You can also contact us using one of the following channels:
 - [GraphQL Mutations](https://docs.hasura.io/1.0/graphql/manual/mutations/index.html)
 - [GraphQL Subscriptions](https://docs.hasura.io/1.0/graphql/manual/subscriptions/index.html)
 - [Event Triggers](https://docs.hasura.io/1.0/graphql/manual/event-triggers/index.html)
-- [Authentication/Access control](https://docs.hasura.io/1.0/graphql/manual/event-triggers/index.html)
+- [Authentication/Access control](https://docs.hasura.io/1.0/graphql/manual/auth/index.html)
 - [Database Migrations](https://docs.hasura.io/1.0/graphql/manual/migrations/index.html)
 - [Guides/Tutorials/Resources](https://docs.hasura.io/1.0/graphql/manual/guides/index.html)


### PR DESCRIPTION
Was using the wrong URL for Authentication/Access control in the README, so I fixed it.