### PR TITLE
set connection pool size to max limit in hobby tier

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,10 @@ ENV HASURA_GRAPHQL_ENABLE_CONSOLE=true
 # Enable debugging mode. It should be disabled in production.
 ENV HASURA_GRAPHQL_DEV_MODE=true
 
+# Heroku hobby tier PG has few limitations including 20 max connections
+# https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier
+ENV HASURA_GRAPHQL_PG_CONNECTIONS=20
+
 # Change $DATABASE_URL to your heroku postgres URL if you're not using
 # the primary postgres instance in your app
 CMD graphql-engine \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV HASURA_GRAPHQL_DEV_MODE=true
 
 # Heroku hobby tier PG has few limitations including 20 max connections
 # https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier
-ENV HASURA_GRAPHQL_PG_CONNECTIONS=20
+ENV HASURA_GRAPHQL_PG_CONNECTIONS=15
 
 # Change $DATABASE_URL to your heroku postgres URL if you're not using
 # the primary postgres instance in your app


### PR DESCRIPTION
Add `ENV HASURA_GRAPHQL_PG_CONNECTIONS=20` to respect heroku hobby-tier limitations: https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier
