### PR TITLE
update graphql-engine version to v2.11.0-beta.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hasura/graphql-engine:v2.9.0-heroku.1
+FROM hasura/graphql-engine:v2.11.0-beta.1
 
 # Enable the console
 ENV HASURA_GRAPHQL_ENABLE_CONSOLE=true
@@ -7,7 +7,7 @@ ENV HASURA_GRAPHQL_ENABLE_CONSOLE=true
 ENV HASURA_GRAPHQL_DEV_MODE=true
 
 # Heroku only allows to install extensions in the heroku_ext schema
-ENV HASURA_GRAPHQL_DEFAULT_EXTENSIONS_SCHEMA=heroku_ext
+ENV HASURA_GRAPHQL_METADATA_DATABASE_EXTENSIONS_SCHEMA=heroku_ext
 
 # Heroku hobby tier PG has few limitations including 20 max connections
 # https://devcenter.heroku.com/articles/heroku-postgres-plans#hobby-tier


### PR DESCRIPTION
One click URL to test the changes in this PR: https://dashboard.heroku.com/new?template=https://github.com/hasura/graphql-engine-heroku/tree/update-hge-to-v2.11