### PR TITLE
update graphql-engine version to v2.10.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hasura/graphql-engine:v2.11.0-beta.1
+FROM hasura/graphql-engine:v2.10.1
 
 # Enable the console
 ENV HASURA_GRAPHQL_ENABLE_CONSOLE=true


### PR DESCRIPTION
One click URL to test the changes in this PR: https://dashboard.heroku.com/new?template=https://github.com/hasura/graphql-engine-heroku/tree/update-hge-to-v2.10.1