### PR TITLE
update graphql-engine version to v2.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hasura/graphql-engine:v2.11.2
+FROM hasura/graphql-engine:v2.12.0
 
 # Enable the console
 ENV HASURA_GRAPHQL_ENABLE_CONSOLE=true


### PR DESCRIPTION
Manual workaround for job failure https://buildkite.com/hasura/release-graphql-engine-ee-lite/builds/16