### PR TITLE
Update app.json

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
   "stack": "container",
   "addons": [
     {
-      "plan": "heroku-postgresql:hobby-dev"
+      "plan": "heroku-postgresql:mini"
     }
   ]
 }


### PR DESCRIPTION
hobby-dev is no longer supported by heroku, so it should be mini instead atleast.